### PR TITLE
fix(parsers): Update handling of datetime in chromeleon parsing

### DIFF
--- a/docs/notebooks/parsing.ipynb
+++ b/docs/notebooks/parsing.ipynb
@@ -75,6 +75,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a467d19a",
+   "metadata": {},
+   "source": [
+    "**Note on Chromeleon date parsing:** the `Inject Time` field's day/month order is read from the exporting machine's OS locale. Where the date is unambiguous (one of the two components is >12), the order is detected automatically. When it's genuinely ambiguous (both components <=12), `dayfirst=True` is assumed by default."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "564bb3a5",
    "metadata": {},
    "source": [
@@ -110,7 +118,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "chromstream (3.11.6)",
+   "display_name": "chromstream (3.11.15.final.0)",
    "language": "python",
    "name": "python3"
   },
@@ -124,7 +132,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,

--- a/src/chromstream/parsers/chromeleon.py
+++ b/src/chromstream/parsers/chromeleon.py
@@ -7,7 +7,9 @@ from chromstream.objects import ChannelChromatograms
 from typing import Optional
 
 
-def parse_chromeleon_txt(file_path: str | Path) -> tuple[dict[str, str], pd.DataFrame]:
+def parse_chromeleon_txt(
+    file_path: str | Path,
+) -> tuple[dict[str, str], pd.DataFrame]:
     """
     Parses a txt file exporeted using chromeleon software into a dict of metadata and pd.DataFrame for chromatogram data.
 
@@ -122,7 +124,9 @@ def parse_chromeleon_txt(file_path: str | Path) -> tuple[dict[str, str], pd.Data
     return metadata, chromatogram_df
 
 
-def parse_inject_time(inject_time: str, metadata: dict) -> pd.Timestamp:
+def parse_inject_time(
+    inject_time: str, metadata: dict, dayfirst: bool = True
+) -> pd.Timestamp:
     """
     Parses the injeciton time for chromeleon txt files into a pd.Timestamp object.
     The file most likely adopts the datatime format of the machine, meaning it can be very different between machines.
@@ -131,21 +135,30 @@ def parse_inject_time(inject_time: str, metadata: dict) -> pd.Timestamp:
     Args:
         inject_time (pd.Timestamp): The Inject Time timestamp to parse.
         metadata (dict): Metadata dictionary containing additional information.
+        dayfirst (bool): Default day/month order used only when the date is
+            genuinely ambiguous (both components <=12) and can't be resolved
+            from the data itself. Defaults to True.
 
     Returns:
         pd.Timestamp: Parsed datetime object.
     """
-    # Check for format like '7/17/2023 3:35:22 PM +02:00'
-    if re.match(
-        r"\d{1,2}/\d{1,2}/\d{4} \d{1,2}:\d{2}:\d{2} (AM|PM) \+\d{2}:\d{2}", inject_time
-    ):
-        return pd.to_datetime(inject_time).tz_localize(None)
-
-    # Check for format like '17-1-2023 16:45:42 +01:00'
-    if re.match(r"\d{1,2}-\d{1,2}-\d{4} \d{2}:\d{2}:\d{2} \+\d{2}:\d{2}", inject_time):
-        return pd.to_datetime(inject_time, format="%d-%m-%Y %H:%M:%S %z").tz_localize(
-            None
-        )
+    # Full date+time string, e.g. '7/17/2023 3:35:22 PM +02:00',
+    # '17-1-2023 16:45:42 +01:00', '17/07/2023 15:35:22 +0200'.
+    # Day/month order depends on the exporting machine's OS locale. Where one
+    # of the two components is >12 the order is unambiguous and can be read
+    # straight from the data instead of guessed; only fall back to the
+    # configured `dayfirst` default when both components are <=12.
+    date_match = re.match(r"(\d{1,2})[/-](\d{1,2})[/-]\d{4}", inject_time)
+    if date_match:
+        first, second = int(date_match.group(1)), int(date_match.group(2))
+        if first > 12:
+            resolved_dayfirst = True
+        elif second > 12:
+            resolved_dayfirst = False
+        else:
+            resolved_dayfirst = dayfirst
+        parsed = pd.to_datetime(inject_time, dayfirst=resolved_dayfirst)
+        return parsed.tz_localize(None) if parsed.tzinfo is not None else parsed
 
     # Check for format like '1:43:35 PM' and require metadata for the date
     if re.match(r"\d{1,2}:\d{2}:\d{2} (AM|PM)", inject_time):
@@ -181,7 +194,8 @@ def parse_inject_time(inject_time: str, metadata: dict) -> pd.Timestamp:
     else:
         try:
             # Attempt to parse as ISO 8601 format
-            time = pd.to_datetime(inject_time).tz_localize(None)
+            # dayfirst is treated as default.
+            time = pd.to_datetime(inject_time, dayfirst=dayfirst).tz_localize(None)
             log.info(f"Time format not handled, but succeeded parsing with: {time}")
             return time
         except Exception:


### PR DESCRIPTION
Adresses #17 

Update to handling of the injection time in chromeleon parsing. 
Instead of using multiple regexes, it now use pandas to_datetime.

Important: if the format is ambigious, e.g. 2/10/2025, the default is dayfirst=True